### PR TITLE
docker-compose config for MongoDB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# MONGODB
+MONGODB_PORT=27017
+MONGODB_USER=mongodbadmin
+MONGODB_PASSWORD=secret
+MONGODB_NAME=ufabc-next-users

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  mongodb:
+    image: mongo:5.0.2
+    env_file:
+      - .env
+    container_name: $MONGODB_NAME
+    restart: always
+    ports:
+      - $MONGODB_PORT:$MONGODB_PORT
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: $MONGODB_USER
+      MONGO_INITDB_ROOT_PASSWORD: $MONGODB_PASSWORD
+      MONGO_INITDB_DATABASE: $MONGODB_NAME
+    


### PR DESCRIPTION
Added a simple docker-compose config for a MongoDB container using mongo:5.0.2 image. Also added a .env.example file. I decided to make the container use .env by default, so just copy everything on .env.example to a .env file to be able to create the container.